### PR TITLE
use async/await in the code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,13 @@ function initJsBundle(options = {}) {
     options.minify = false
   }
 
-  return function jsBundle(files, metalsmith, done) {
+  return async function jsBundle(files, metalsmith) {
     const debug = metalsmith.debug(debugNs)
 
     options = normalizeOptions(options, metalsmith, debug)
     if (Object.keys(options.entryPoints).length === 0) {
       debug.warn('No files to process, skipping.')
-      done()
+      return
     }
 
     options.entryPoints = Object.entries(options.entryPoints).reduce((mapped, current) => {
@@ -96,49 +96,42 @@ function initJsBundle(options = {}) {
     debug('Running with options %O', options)
     const sourceRelPath = relative(metalsmith.directory(), metalsmith.source())
 
-    build(options)
-      .then((result) => {
-        debug(
-          'Finished bundling %O',
-          result.outputFiles.map((o) => relative(metalsmith.destination(), o.path))
-        )
+    const result = await build(options)
+    debug(
+      'Finished bundling %O',
+      result.outputFiles.map((o) => relative(metalsmith.destination(), o.path))
+    )
 
-        // first read esbuild metafile to remove the compilation inputs from the build
-        Object.values(result.metafile.outputs).forEach((o) => {
-          if (o.inputs) {
-            metalsmith.match(`${sourceRelPath}/**`, Object.keys(o.inputs)).forEach((input) => {
-              delete files[relative(metalsmith.source(), metalsmith.path(input))]
-            })
-          }
+    // first read esbuild metafile to remove the compilation inputs from the build
+    Object.values(result.metafile.outputs).forEach((o) => {
+      if (o.inputs) {
+        metalsmith.match(`${sourceRelPath}/**`, Object.keys(o.inputs)).forEach((input) => {
+          delete files[relative(metalsmith.source(), metalsmith.path(input))]
         })
+      }
+    })
 
-        result.outputFiles.forEach((file) => {
-          // For in-source files, esbuild returns entries in the format 'build/src/path/to/file.ext'
-          // first we strip the metalsmith.destination()
-          let destPath = relative(metalsmith.destination(), file.path)
+    result.outputFiles.forEach((file) => {
+      // For in-source files, esbuild returns entries in the format 'build/src/path/to/file.ext'
+      // first we strip the metalsmith.destination()
+      let destPath = relative(metalsmith.destination(), file.path)
 
-          // if the file was in-source, we strip the source path part (eg 'src') too.
-          if (destPath.startsWith(sourceRelPath)) {
-            destPath = relative(metalsmith.source(), metalsmith.path(destPath))
-          }
+      // if the file was in-source, we strip the source path part (eg 'src') too.
+      if (destPath.startsWith(sourceRelPath)) {
+        destPath = relative(metalsmith.source(), metalsmith.path(destPath))
+      }
 
-          files[destPath] = {
-            contents: Buffer.from(file.contents.buffer)
-          }
-          if (babelPostProcess && extname(destPath) === '.js') {
-            files[destPath].__babelPostProcess = true
-          }
-        })
+      files[destPath] = {
+        contents: Buffer.from(file.contents.buffer)
+      }
+      if (babelPostProcess && extname(destPath) === '.js') {
+        files[destPath].__babelPostProcess = true
+      }
+    })
 
-        if (babelPostProcess) {
-          es5Plugin()(files, metalsmith, done)
-        } else {
-          done()
-        }
-      })
-      .catch((err) => {
-        done(err)
-      })
+    if (babelPostProcess) {
+      await es5Plugin()(files, metalsmith)
+    }
   }
 }
 


### PR DESCRIPTION
removes callbacks for both metalsmith and babel and relies on standard
exception mechanism for error handling
